### PR TITLE
Adding the ability to start the petclinic client + a clustered active…

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -21,6 +21,11 @@ RUN mvn package -DskipTests
 # expose the webapp port
 EXPOSE 9966
 
-ENTRYPOINT ["mvn", "tomcat7:run", "-Dtsa_hostname=tsa"]
+# the default TSA url - can be overriden to match your environments
+ENV TSA_URL 'tsa:9510'
 
+# use a custom entry point to be able to read the ENV var properly
+COPY ./docker-entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/docker-entrypoint.sh
 
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/client/docker-compose-AandP.yml
+++ b/client/docker-compose-AandP.yml
@@ -1,0 +1,42 @@
+version: '3'
+services:
+  petclinic:
+    #image: anthonydahanne/spring-petclinic-clustered:4.3.2
+    build: .
+    ports:
+      - "9966:9966"
+    networks:
+      - myTSANet
+    environment:
+      - TSA_URL=tsa1:9510,tsa2:9510
+    links:
+      - tsa1
+      - tsa2
+  tsa1:
+    image: anthonydahanne/terracotta-server-oss:4.3.2
+    hostname: tsa1
+    networks:
+      myTSANet:
+        aliases:
+          - tsa1
+    ports:
+      - "9510:9510"
+      - "9530:9530"
+    environment:
+      - TC_SERVER1=tsa1
+      - TC_SERVER2=tsa2
+  tsa2:
+    image: anthonydahanne/terracotta-server-oss:4.3.2
+    hostname: tsa2
+    networks:
+      myTSANet:
+        aliases:
+          - tsa2
+    ports:
+      - "9610:9510"
+      - "9630:9530"
+    environment:
+      - TC_SERVER1=tsa1
+      - TC_SERVER2=tsa2
+networks:
+  myTSANet:

--- a/client/docker-entrypoint.sh
+++ b/client/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "Inside entrypoint -- Will connect the app to TSA_URL = ${TSA_URL}"
+
+# start the app using maven command
+mvn tomcat7:run -Dtsa_url=${TSA_URL}


### PR DESCRIPTION
… / passive TSA

Hey so this pull request goes hand-in-hand with the other pull request for the pet clinic...
Basically, while setting this up, I realized that I could not spin up a full example with a clustered TSA directly from a docker-compose script...
So I created a new docker-compose-AandP.yml that allows that...and it uses a ENV variable to set the TSA url... (somehow, it seems like ENV variable do not get expanded in entrypoint["",""] so I added a new docker-entrypoint.sh as well to launch the pet clinic exec...
Long story short, I made it all work in my local...but wanted to pull it back to yours as I think it may be a useful example...

Let me know your thoughts!!

Fabien